### PR TITLE
Ignore old packages that are no longer on the devel branch.

### DIFF
--- a/rolling.ignored
+++ b/rolling.ignored
@@ -1,0 +1,2 @@
+ros_ign_gazebo_demos
+ros_ign_gazebo


### PR DESCRIPTION
Bloom searches for branches matching a pattern to pick packages to release so these old branches either need to be deleted or their contents ignored. (https://github.com/ros-infrastructure/bloom/issues/737).

This will prevent the packages from being released when creating releases for rolling.